### PR TITLE
makes `root` a more accurate parent of file tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ inquirer.prompt({
 ```
 
 ### Options
-Takes type, name, message[filter, validate, default, pageSize, onlyShowDir, root] properties.
+Takes `type`, `name`, `message`, [`filter`, `validate`, `default`, `pageSize`, `onlyShowDir`, `root`, `hideRoot`] properties.
 The extra options that this plugin provides are:
 - `onlyShowDir`:  (Boolean) if true, will only show directory. Default: false.
 - `root`: (String) it is the root of file tree. Default: process.cwd().
+- `hideRoot`: (Boolean) if true, will hide the root directory. Default: false.
 
 ### Example
 ```

--- a/index.js
+++ b/index.js
@@ -23,20 +23,27 @@ class FileTreeSelectionPrompt extends Base {
   constructor(questions, rl, answers) {
     super(questions, rl, answers);
 
-    this.fileTree = dirTree(path.resolve(process.cwd(), this.opt.root || '.'))
+    const root = path.resolve(process.cwd(), this.opt.root || '.');
+    this.fileTree = dirTree(root)
     this.fileTree.children = this.fileTree.children || []
 
-    this.fileTree.children.unshift({
-      path: process.cwd(),
-      type: 'directory',
-      isCurrentDirectory: true,
-      name: '.(current directory)'
-    })
+    if (this.opt.hideRoot) {
+      this.selected = this.fileTree.children[0];
+    } else {
+      this.fileTree.children = [{
+        path: root,
+        type: 'directory',
+        isCurrentDirectory: true,
+        name: '.(root directory)',
+        open: true,
+        children: this.fileTree.children,
+      }];
+      this.selected = this.fileTree.children[0].children[0];
+    }
 
     this.shownList = []
 
     this.firstRender = true;
-    this.selected = this.fileTree.children[0];
 
     this.opt = {
       ...{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "inquirer-file-tree-selection-prompt",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixes #5 

The proposed change does a few things:

1. Changes `.(current directory)` to `.(root directory)`
2. Makes `.(root directory)` path equal to user specified `root` rather than always `process.cwd()`
3. Nests all other files/folders as children of `root`
4. Adds an option to `hideRoot`, thus only rendering children in the message, and not `root` itself 