### PR TITLE
adds support for `transformer` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ inquirer.prompt({
 ```
 
 ### Options
-Takes type, name, message[filter, validate, default, pageSize, onlyShowDir, root] properties.
+Takes `type`, `name`, `message`,[`filter`, `validate`, `transformer`, `default`, `pageSize`, `onlyShowDir`, `root`] properties.
 The extra options that this plugin provides are:
 - `onlyShowDir`:  (Boolean) if true, will only show directory. Default: false.
 - `root`: (String) it is the root of file tree. Default: process.cwd().

--- a/example/demo.js
+++ b/example/demo.js
@@ -1,5 +1,7 @@
 const inquirer = require('inquirer')
 const inquirerFileTreeSelection = require('../index')
+const path = require('path');
+const chalk = require('chalk');
 
 inquirer.registerPrompt('file-tree-selection', inquirerFileTreeSelection)
 
@@ -8,7 +10,14 @@ inquirer
     {
       type: 'file-tree-selection',
       name: 'file',
-      message: 'choose a file'
+      message: 'choose a file',
+      transformer: (input) => {
+        const name = input.split(path.sep).pop();
+        if (name[0] == ".") {
+          return chalk.grey(name);
+        }
+        return name;
+      }
     }
   ])
   .then(answers => {

--- a/index.js
+++ b/index.js
@@ -92,6 +92,9 @@ class FileTreeSelectionPrompt extends Base {
   renderFileTree(root = this.fileTree, indent = 2) {
     const children = root.children || []
     let output = ''
+    const transformer = this.opt.transformer;
+    const isFinal = this.status === 'answered';
+    let showValue;
 
     children.forEach(itemPath => {
       if (this.opt.onlyShowDir && itemPath.type !== 'directory') {
@@ -103,8 +106,16 @@ class FileTreeSelectionPrompt extends Base {
         ? itemPath.open
           ? figures.arrowDown + ' '
           : figures.arrowRight + ' '
-        : ''
-      const showValue = ' '.repeat(prefix ? indent - 2 : indent) + prefix + itemPath.name + '\n'
+        : itemPath === this.selected
+          ? figures.play + ' '
+          : ''
+
+      if (transformer) {
+        const transformedValue = transformer(itemPath.path, this.answers, { isFinal });
+        showValue = ' '.repeat(prefix ? indent - 2 : indent) + prefix + transformedValue + '\n';
+      } else {
+        showValue = ' '.repeat(prefix ? indent - 2 : indent) + prefix + itemPath.name + '\n'
+      }
 
       if (itemPath === this.selected) {
         output += chalk.cyan(showValue)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "inquirer-file-tree-selection-prompt",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixes #7 

This PR adds the capability for a user to specify a `transform` function.  A use case where this would be useful is when the user would like to change the output (i.e. color) of the message via `chalk` methods, or perhaps add amplifying metadata about each file/folder (i.e. date modified).

Since the current way of knowing which row is selected relies on `chalk.cyan`, this new capability might make it difficult to know which row is active if the user overrides the color.  Thus, this PR also adds a `figures.play` arrow to the selected row (when it is not a directory) as the prefix.