### PR TITLE
adds two options: `onlyShowValid` and `hideChildrenOfValid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ inquirer.prompt({
 ```
 
 ### Options
-Takes type, name, message[filter, validate, default, pageSize, onlyShowDir, root] properties.
+Takes `type`, `name`, `message`, [`filter`, `validate`, `default`, `pageSize`, `onlyShowDir`, `onlyShowValid`, `hideChildrenOfValid`, `root`] properties.
 The extra options that this plugin provides are:
 - `onlyShowDir`:  (Boolean) if true, will only show directory. Default: false.
 - `root`: (String) it is the root of file tree. Default: process.cwd().
+- `onlyShowValid`: (Boolean) if true, will only show valid files (if `validate` is provided). Default: false.
+- `hideChildrenOfValid`: (Boolean) if true, will hide children of valid directories (if `validate` is provided). Default: false.
 
 ### Example
 ```

--- a/example/demo.js
+++ b/example/demo.js
@@ -1,5 +1,6 @@
 const inquirer = require('inquirer')
 const inquirerFileTreeSelection = require('../index')
+const path = require('path');
 
 inquirer.registerPrompt('file-tree-selection', inquirerFileTreeSelection)
 
@@ -8,7 +9,15 @@ inquirer
     {
       type: 'file-tree-selection',
       name: 'file',
-      message: 'choose a file'
+      message: 'choose a file',
+      validate: (item) => {
+        const name = item.split(path.sep).pop();
+        if (name[0] != ".") {
+          return "please select another file"
+        }
+        return true;
+      },
+      onlyShowValid: true
     }
   ])
   .then(answers => {

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class FileTreeSelectionPrompt extends Base {
    * @return {this}
    */
 
-  _run(cb) {
+  async _run(cb) {
     this.done = cb;
 
     var self = this;
@@ -83,6 +83,45 @@ class FileTreeSelectionPrompt extends Base {
 
     cliCursor.hide();
     if (this.firstRender) {
+      const validate = this.opt.validate;
+      if (validate) {
+        const asyncForEach = async (array, callback) => {
+          for (let index = 0; index < array.length; index++) {
+            await callback(array[index], index, array);
+          }
+        };
+        const addValidity = async (fileObj) => {
+          const isValid = await validate(fileObj.path);
+          fileObj.isValid = false;
+          if (isValid === true) {
+            if (this.opt.onlyShowDir) {
+              if (fileObj.type == 'directory') {
+                fileObj.isValid = true;
+              }
+            } else {
+              fileObj.isValid = true;
+            }
+          }
+          if (fileObj.children) {
+            if (this.opt.hideChildrenOfValid && fileObj.isValid) {
+              fileObj.children.length = 0;
+            }
+            const children = fileObj.children.map(x => x);
+            for (let index = 0, length = children.length; index < length; index++) {
+              const child = children[index];
+              await addValidity(child);
+              if (child.isValid) {
+                fileObj.hasValidChild = true;
+              }
+              if (this.opt.onlyShowValid && !child.hasValidChild && !child.isValid) {
+                const spliceIndex = fileObj.children.indexOf(child);
+                fileObj.children.splice(spliceIndex, 1);
+              }
+            }
+          }
+        }
+        await addValidity(this.fileTree);
+      }
       this.render();
     }
 
@@ -99,15 +138,18 @@ class FileTreeSelectionPrompt extends Base {
       }
 
       this.shownList.push(itemPath)
-      let prefix = itemPath.children
+      let prefix = itemPath.children && itemPath.children.length
         ? itemPath.open
           ? figures.arrowDown + ' '
           : figures.arrowRight + ' '
         : ''
       const showValue = ' '.repeat(prefix ? indent - 2 : indent) + prefix + itemPath.name + '\n'
 
-      if (itemPath === this.selected) {
+      if (itemPath === this.selected && itemPath.isValid) {
         output += chalk.cyan(showValue)
+      }
+      else if (itemPath === this.selected && !itemPath.isValid) {
+        output += chalk.red(showValue)
       }
       else {
         output += showValue

--- a/index.js
+++ b/index.js
@@ -85,11 +85,6 @@ class FileTreeSelectionPrompt extends Base {
     if (this.firstRender) {
       const validate = this.opt.validate;
       if (validate) {
-        const asyncForEach = async (array, callback) => {
-          for (let index = 0; index < array.length; index++) {
-            await callback(array[index], index, array);
-          }
-        };
         const addValidity = async (fileObj) => {
           const isValid = await validate(fileObj.path);
           fileObj.isValid = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "inquirer-file-tree-selection-prompt",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixes #9 

This is perhaps the most complicated of my recent pull requests, but in my opinion the most useful...

The bulk of new code in this PR is to pre-validate the file tree before it is rendered for the first time.  If the user doesn't provide a `validate` function, then these options aren't triggered.  If they do provide a `validate` function, this will add the following new options:
1. `onlyShowValid` is a boolean which, when true, removes any file that isn't valid, and any folder that doesn't have a valid child.
2. `hideChildrenOfValid` is a boolean which, when true, removes all children of a folder that is marked as valid (based on the `validate` function)

The first is pretty self-explanatory, and probably doesn't need any elaboration.  However, the benefits of the latter may be more clear with a couple use cases.  

If the purpose of the question is for the user to select a project directory from a file tree, then the `validate` method can check for the presence of a `package.json` file as a child of each directory.  If the directory is thus valid, then there is no need to render any of it's children as the directory itself is the desired target for that question.

Similarly, the question may want the user to select a web application from a web server.  In this case, the `validate` function may check for the presence of a `web.config`, `.htaccess`, or `index.html`.  Setting `hideChildrenOfValid` would prevent the user from going deeper into the app's folder structure than necessary to answer the question.