### PR TITLE
Fix keyword typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepublish": "npm run changelog"
   },
   "keywords": [
-    "inquerer",
+    "inquirer",
     "filetree"
   ],
   "author": "anc95",


### PR DESCRIPTION
It seems like there is a typo in the `inquirer` keyword. This PR fixes it.