### PR TITLE
Add support for multiple states for the file selection

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,17 +44,22 @@ class FileTreeSelectionPrompt extends Base {
         pageSize: 10,
         onlyShowDir: false,
         multiple: false,
-        states: false
+        states: false,
+        selectedList: false,
       },
       ...this.opt
     }
 
     // Make sure no default is set (so it won't be printed)
     this.opt.default = null;
-    if (this.opt.states) {
-      this.selectedList = {};
+    if (this.opt.selectedList) {
+      this.selectedList = this.opt.selectedList
     } else {
-      this.selectedList = [];
+      if (this.opt.states) {
+        this.selectedList = {};
+      } else {
+        this.selectedList = [];
+      }
     }
     this.paginator = new Paginator(this.screen);
   }

--- a/index.js
+++ b/index.js
@@ -51,7 +51,11 @@ class FileTreeSelectionPrompt extends Base {
 
     // Make sure no default is set (so it won't be printed)
     this.opt.default = null;
-    this.selectedList = {};
+    if (this.opt.states) {
+      this.selectedList = {};
+    } else {
+      this.selectedList = [];
+    }
     this.paginator = new Paginator(this.screen);
   }
 
@@ -144,7 +148,7 @@ class FileTreeSelectionPrompt extends Base {
         if (this.opt.states) {
           prefix += itemPath.path in this.selectedList ? this.opt.states.find((state) => state.state == this.selectedList[itemPath.path]).label : figures.radioOff;
         } else {
-          prefix += itemPath.path in this.selectedList ? figures.radioOn : figures.radioOff;
+          prefix += this.selectedList.includes(itemPath.path) ? figures.radioOn : figures.radioOff
         }
         prefix += ' ';
       }
@@ -352,16 +356,24 @@ class FileTreeSelectionPrompt extends Base {
         return
       }
 
-      if (this.active.path in this.selectedList) {
-        let nextStateIndex = 1 + this.opt.states.findIndex((state) => state.state == this.selectedList[this.active.path]);
-        if (nextStateIndex < this.opt.states.length) {
-          this.selectedList[this.active.path] = this.opt.states[nextStateIndex].state;
+      if (this.opt.states) {
+        if (this.active.path in this.selectedList) {
+          let nextStateIndex = 1 + this.opt.states.findIndex((state) => state.state == this.selectedList[this.active.path]);
+          if (nextStateIndex < this.opt.states.length) {
+            this.selectedList[this.active.path] = this.opt.states[nextStateIndex].state;
+          } else {
+            delete this.selectedList[this.active.path];
+          }
         } else {
-          delete this.selectedList[this.active.path];
+          this.selectedList[this.active.path] = this.opt.states[0].state;
         }
-      }
-      else {
-        this.selectedList[this.active.path] = this.opt.states[0].state;
+      } else {
+        if (this.selectedList.includes(this.active.path)) {
+          this.selectedList.splice(this.selectedList.indexOf(this.active.path), 1);
+        }
+        else {
+          this.selectedList.push(this.active.path);
+        }
       }
 
       this.render()

--- a/index.js
+++ b/index.js
@@ -43,14 +43,15 @@ class FileTreeSelectionPrompt extends Base {
         default: null,
         pageSize: 10,
         onlyShowDir: false,
-        multiple: false
+        multiple: false,
+        states: false
       },
       ...this.opt
     }
 
     // Make sure no default is set (so it won't be printed)
     this.opt.default = null;
-    this.selectedList = [];
+    this.selectedList = {};
     this.paginator = new Paginator(this.screen);
   }
 
@@ -140,7 +141,11 @@ class FileTreeSelectionPrompt extends Base {
 
       // when multiple is true, add radio icon at prefix
       if (this.opt.multiple) {
-        prefix += this.selectedList.includes(itemPath.path) ? figures.radioOn : figures.radioOff;
+        if (this.opt.states) {
+          prefix += itemPath.path in this.selectedList ? this.opt.states.find((state) => state.state == this.selectedList[itemPath.path]).label : figures.radioOff;
+        } else {
+          prefix += itemPath.path in this.selectedList ? figures.radioOn : figures.radioOff;
+        }
         prefix += ' ';
       }
       const safeIndent = (indent - prefix.length + 2) > 0
@@ -189,9 +194,9 @@ class FileTreeSelectionPrompt extends Base {
       });
 
       node.children = children;
-    } catch (e) { 
+    } catch (e) {
       // maybe for permission denied, we cant read the dir
-      // do nothing here  
+      // do nothing here
     }
 
     const validate = this.opt.validate;
@@ -254,7 +259,7 @@ class FileTreeSelectionPrompt extends Base {
     }
 
     if (this.status === 'answered') {
-      message += chalk.cyan(this.opt.multiple ? this.selectedList.join(', ') : this.active.path)
+      message += chalk.cyan(this.opt.multiple ? JSON.stringify(this.selectedList) : this.active.path)
     }
     else {
       this.shownList = []
@@ -347,11 +352,16 @@ class FileTreeSelectionPrompt extends Base {
         return
       }
 
-      if (this.selectedList.includes(this.active.path)) {
-        this.selectedList.splice(this.selectedList.indexOf(this.active.path), 1);
+      if (this.active.path in this.selectedList) {
+        let nextStateIndex = 1 + this.opt.states.findIndex((state) => state.state == this.selectedList[this.active.path]);
+        if (nextStateIndex < this.opt.states.length) {
+          this.selectedList[this.active.path] = this.opt.states[nextStateIndex].state;
+        } else {
+          delete this.selectedList[this.active.path];
+        }
       }
       else {
-        this.selectedList.push(this.active.path);
+        this.selectedList[this.active.path] = this.opt.states[0].state;
       }
 
       this.render()


### PR DESCRIPTION
Close #37 .

How do you like this implementation for multiple selection states? For sure the code could be more elegant, but it works and preserves the old behavior.

Usage example:

```javascript
const inquirer = require('inquirer')
const inquirerFileTreeSelection = require('inquirer-file-tree-selection-prompt')
const figures = require('figures');

inquirer.registerPrompt('file-tree-selection', inquirerFileTreeSelection)

inquirer
  .prompt([
    {
      type: 'file-tree-selection',
      name: 'file',
      multiple: true,
      states: [{state: 'ignored', label: 'i'}, {state: 'selected', label: figures.radioOn}]
    }
  ])
  .then(answers => {
    console.log(JSON.stringify(answers))
  });

```

will result in output like

```
{"file":{"/home/…/file.log":"ignored","/home/…/node_modules":"selected"}}
```