### PR TITLE
Remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "chalk": "^5.0.1",
     "cli-cursor": "^4.0.0",
     "figures": "^4.0.1",
-    "lodash": "^4.17.21",
     "rxjs": "^7.5.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello, and thanks for updating this for ESM support!

While updating, I noticed that you're not using the lodash dependency anymore.